### PR TITLE
Set no local server as well as browser

### DIFF
--- a/foundry/foundry.py
+++ b/foundry/foundry.py
@@ -114,7 +114,8 @@ class Foundry(FoundryMetadata):
     
     transfer_client = mdf_toolbox.login(services=__services, 
                                         app_name=__app_name,
-                                        no_browser=True)[
+                                        no_browser=True,
+                                        no_local_server=True)[
         "transfer"
     ]
     dlhub_client = DLHubClient()


### PR DESCRIPTION
Adds the no local server arg to the mdf_toolbox call.