### PR TITLE
attempted fix to get rid of f=f.load() call in general

### DIFF
--- a/foundry/foundry.py
+++ b/foundry/foundry.py
@@ -147,7 +147,7 @@ class Foundry(FoundryMetadata):
         # handle empty dataset name (was returning all the datasets)
         if not name:
             raise ValueError("load: No dataset name is given")
-            
+
         if metadata:
             res = metadata
 
@@ -182,7 +182,14 @@ class Foundry(FoundryMetadata):
 
         # TODO: Creating a new Foundry instance is a problematic way to update the metadata,
         # we should find a way to abstract this.
-        self = Foundry(**res, index=self.index, authorizers=authorizers)
+
+        f = Foundry(**res, index=self.index, authorizers=authorizers)
+
+        self.dc = f.dc
+        self.mdf = f.mdf
+        self.dataset = f.dataset
+
+        #print("Attempt 1:", self)
 
         if download is True:  # Add check for package existence
             self.download(


### PR DESCRIPTION
Fix contained in foundry load() function. Not entirely sure if this is the most CORRECT fix since it still involves instantiating an object, but in other attempts the object either wouldn't look quite right or things would go wrong elsewhere 

Also question -- since ideally we won't need to use the f = f.load() call, do we still need the return line at the end, or does it not make a difference? 
(We made sure and tested the code locally that when we removed the return line, everything still worked normally)