### PR TITLE
should only test on prs to main and dev now

### DIFF
--- a/.github/workflows/testing-work.yml
+++ b/.github/workflows/testing-work.yml
@@ -2,9 +2,9 @@ name: testing-work
 
 on:
   pull_request:
-  push:
     branches:
       - dev
+      - main 
 
 jobs:
   build:


### PR DESCRIPTION
Change should no longer run the github action tests on pushes 