### PR TITLE
establish run() function again

### DIFF
--- a/foundry/foundry.py
+++ b/foundry/foundry.py
@@ -113,7 +113,7 @@ class Foundry(FoundryMetadata):
         ## TODO: come back to add in DLHub functionality after globus-sdk>=3.0 supported
         self.dlhub_client = DLHubClient(
             dlh_authorizer=auths["dlhub"],
-            search_client=auths["search"],
+            search_authorizer=auths["search_authorizer"],
             fx_authorizer=auths[
                 "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all"
             ],

--- a/foundry/foundry.py
+++ b/foundry/foundry.py
@@ -16,7 +16,7 @@ from mdf_forge import Forge
 # from dlhub_sdk.utils.schemas import validate_against_dlhub_schema
 # from dlhub_sdk.models.servables.keras import KerasModel
 # from dlhub_sdk.models.servables.sklearn import ScikitLearnModel
-# from dlhub_sdk import DLHubClient
+from dlhub_sdk import DLHubClient
 from collections import namedtuple
 from joblib import Parallel, delayed
 from pydantic import AnyUrl, ValidationError
@@ -43,7 +43,7 @@ class Foundry(FoundryMetadata):
     """
 
     # transfer_client: Any
-    # dlhub_client: Any
+    dlhub_client: Any
     forge_client: Any
     connect_client: Any
     index = ""
@@ -110,15 +110,15 @@ class Foundry(FoundryMetadata):
         )
 
         ## TODO: come back to add in DLHub functionality after globus-sdk>=3.0 supported
-        # self.dlhub_client = DLHubClient(
-        #     dlh_authorizer=auths["dlhub"],
-        #     search_client=auths["search"],
-        #     fx_authorizer=auths[
-        #         "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all"
-        #     ],
-        #     openid_authorizer=auths['openid'],
-        #     force_login=False,
-        # )
+        self.dlhub_client = DLHubClient(
+            dlh_authorizer=auths["dlhub"],
+            search_client=auths["search"],
+            fx_authorizer=auths[
+                "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all"
+            ],
+            openid_authorizer=auths['openid'],
+            force_login=False,
+        )
 
 
         self.xtract_tokens = {
@@ -266,22 +266,18 @@ class Foundry(FoundryMetadata):
 
         return pd.concat(X_frames), pd.concat(y_frames)
 
-    # def run(self, name, inputs, **kwargs):
-    #     """Run a model on data
-    #
-    #     Args:
-    #        name (str): DLHub model name
-    #        inputs: Data to send to DLHub as inputs (should be JSON serializable)
-    #
-    #     Returns
-    #     -------
-    #          Returns results after invocation via the DLHub service
-    #
-    #     TODO:
-    #     -------
-    #     - Pass **kwargs through to DLHub client and document kwargs
-    #     """
-    #     return self.dlhub_client.run(name, inputs=inputs)
+    def run(self, name, inputs, **kwargs):
+        """Run a model on data
+
+        Args:
+           name (str): DLHub model name
+           inputs: Data to send to DLHub as inputs (should be JSON serializable)
+
+        Returns
+        -------
+             Returns results after invocation via the DLHub service
+        """
+        return self.dlhub_client.run(name, inputs=inputs, **kwargs)
 
     def load_data(self, source_id=None, globus=True):
         """Load in the data associated with the prescribed dataset

--- a/foundry/foundry.py
+++ b/foundry/foundry.py
@@ -81,6 +81,7 @@ class Foundry(FoundryMetadata):
                     "petrel",
                     "transfer",
                     "dlhub",
+                    "funcx",
                     "openid",
                     "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",
                 ],

--- a/foundry/requirements.txt
+++ b/foundry/requirements.txt
@@ -1,9 +1,0 @@
-globus-sdk>=1.2.1
-requests>=2.18.4
-tqdm>=4.19.4
-six>=1.11.0
-dlhub_sdk>=0.0.1
-h5py>=2.10.0
-pydantic>=1.6.1
-joblib>=0.16.0
-funcx==0.0.6a5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-globus-sdk>=1.2.1
+globus-sdk>=1.2.1,<=2.0.3
 dlhub_sdk==0.10.0
 requests>=2.18.4
 tqdm>=4.19.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 globus-sdk>=1.2.1
+dlhub_sdk==0.10.0
 requests>=2.18.4
 tqdm>=4.19.4
 six>=1.11.0

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     install_requires=[
         "mdf_forge>=0.7.6",
+        "globus-sdk>=1.2.1,<=2.0.3",
         "dlhub_sdk==0.10.0",
         "numpy>=1.15.4",
         "pandas>=0.23.4",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ packages = (setuptools.find_packages(),)
 # TODO: change dependencies to be looser
 setuptools.setup(
     name="foundry_ml",
-    version="0.1.0",
+    version="0.1.2",
     author="Aristana Scourtas, KJ Schmidt, Imogen Foster, Ribhav Bose, Zoa Katok, Ethan Truelove, Ian Foster, Ben Blaiszik",
     author_email="blaiszik@uchicago.edu",
     packages=setuptools.find_packages(),
@@ -15,6 +15,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     install_requires=[
         "mdf_forge>=0.7.6",
+        "dlhub_sdk==0.10.0",
         "numpy>=1.15.4",
         "pandas>=0.23.4",
         "pydantic>=1.4",

--- a/tests/test_foundry_gha.py
+++ b/tests/test_foundry_gha.py
@@ -20,7 +20,7 @@ services= [
             "data_mdf",
             "mdf_connect",
             "search",
-            "dlhub"
+            "dlhub",
             "petrel",
             "transfer",
             "openid",

--- a/tests/test_foundry_gha.py
+++ b/tests/test_foundry_gha.py
@@ -15,23 +15,26 @@ from mdf_connect_client import MDFConnectClient
 client_id = os.getenv('CLIENT_ID')
 client_secret = os.getenv('CLIENT_SECRET')
 
-# TODO: add dlhub back once supported again
 services= [
             "data_mdf",
             "mdf_connect",
             "search",
             "dlhub",
-            "funcx",
             "petrel",
             "transfer",
             "openid",
             "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",]
 
-res_cred = mdf_toolbox.confidential_login(client_id=client_id,
+auths = mdf_toolbox.confidential_login(client_id=client_id,
                                         client_secret=client_secret,
                                         services=services, make_clients=True)
 
+search_auth = mdf_toolbox.confidential_login(client_id=client_id,
+                                        client_secret=client_secret,
+                                        services=['search'], make_clients=False)
 
+
+auths['search_authorizer'] = search_auth['search']
 
 #updated test dataset
 test_dataset = "_test_foundry_iris_dev_v2.1"
@@ -121,7 +124,7 @@ def _delete_test_data(foundry_obj):
 
 
 def test_foundry_init_cloud():
-    f1 = Foundry(authorizers=res_cred)
+    f1 = Foundry(authorizers=auths)
 #     assert isinstance(f1.dlhub_client, DLHubClient)
     assert isinstance(f1.forge_client, Forge)
     assert isinstance(f1.connect_client, MDFConnectClient)
@@ -129,42 +132,42 @@ def test_foundry_init_cloud():
 
 @pytest.mark.xfail(reason="Tests will fail in cloud")
 def test_foundry_init_cloud():
-    f = Foundry(authorizers=res_cred)
+    f = Foundry(authorizers=auths)
 #     assert isinstance(f.dlhub_client, DLHubClient)
     assert isinstance(f.forge_client, Forge)
     assert isinstance(f.connect_client, MDFConnectClient)
 
-    f2 = Foundry(authorizers=res_cred)
+    f2 = Foundry(authorizers=auths)
 #     assert isinstance(f2.dlhub_client, DLHubClient)
     assert isinstance(f2.forge_client, Forge)
     assert isinstance(f2.connect_client, MDFConnectClient)
 
-    f3 = Foundry(authorizers=res_cred)
+    f3 = Foundry(authorizers=auths)
 #     assert isinstance(f3.dlhub_client, DLHubClient)
     assert isinstance(f3.forge_client, Forge)
     assert isinstance(f3.connect_client, MDFConnectClient)
 
 
 def test_list():
-    f = Foundry(authorizers=res_cred)
+    f = Foundry(authorizers=auths)
     ds = f.list()
     assert isinstance(ds, pd.DataFrame)
     assert len(ds) > 0
 
 def test_metadata_pull():
-    f = Foundry(authorizers=res_cred)
+    f = Foundry(authorizers=auths)
     assert f.dc == {}
-    f = f.load(test_dataset, download=False, authorizers=res_cred)
+    f = f.load(test_dataset, download=False, authorizers=auths)
     assert f.dc["titles"][0]["title"] == expected_title
 
 
 def test_download_https():
 
-    f = Foundry(authorizers=res_cred)
+    f = Foundry(authorizers=auths)
 
     _delete_test_data(f)
 
-    f = f.load(test_dataset, download=True, globus=False, authorizers=res_cred)
+    f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
     assert f.dc["titles"][0]["title"] == expected_title
 
     _delete_test_data(f)
@@ -172,11 +175,11 @@ def test_download_https():
 
 def test_dataframe_load():
 
-    f = Foundry(authorizers=res_cred)
+    f = Foundry(authorizers=auths)
 
     _delete_test_data(f)
 
-    f = f.load(test_dataset, download=True, globus=False, authorizers=res_cred)
+    f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
     res = f.load_data()
     X, y = res['train']
 

--- a/tests/test_foundry_gha.py
+++ b/tests/test_foundry_gha.py
@@ -21,6 +21,7 @@ services= [
             "mdf_connect",
             "search",
             "dlhub",
+            "funcx",
             "petrel",
             "transfer",
             "openid",

--- a/tests/test_foundry_gha.py
+++ b/tests/test_foundry_gha.py
@@ -20,6 +20,7 @@ services= [
             "data_mdf",
             "mdf_connect",
             "search",
+            "dlhub"
             "petrel",
             "transfer",
             "openid",


### PR DESCRIPTION
- re-introduce run() function
- does not include DLHub SDK publication methods; thus, will work on Apple Silicon
- requires `dlhub_sdk==0.10.0`
- requires Globus SDK 2, even though `dlhub_sdk==0.10.0` uses Globus SDK 3