### PR TITLE
Fix init auth

### DIFF
--- a/foundry/foundry.py
+++ b/foundry/foundry.py
@@ -73,8 +73,7 @@ class Foundry(FoundryMetadata):
         if authorizers:
             auths = authorizers
         else:
-            auths = mdf_toolbox.login(
-                services=[
+            services = [
                     "data_mdf",
                     "mdf_connect",
                     "search",
@@ -84,12 +83,24 @@ class Foundry(FoundryMetadata):
                     "funcx",
                     "openid",
                     "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",
-                ],
+                ]
+            auths = mdf_toolbox.login(
+                services=services,
                 app_name="Foundry",
                 make_clients=True,
                 no_browser=no_browser,
                 no_local_server=no_local_server,
             )
+            # request Search as an authorizer and not a client
+            search_auth = mdf_toolbox.login(
+                services=['search'],
+                app_name="Foundry",
+                make_clients=False,
+                no_browser=no_browser,
+                no_local_server=no_local_server,
+            )
+            # add special SearchAuthorizer object
+            auths['search_authorizer'] = search_auth['search']
 
         self.forge_client = Forge(
             index=index,

--- a/foundry/foundry.py
+++ b/foundry/foundry.py
@@ -51,7 +51,7 @@ class Foundry(FoundryMetadata):
     xtract_tokens: Any
 
     def __init__(
-        self, no_browser=False, no_local_server=False, index="mdf-test", authorizers=None, **data
+        self, no_browser=False, no_local_server=False, index="mdf", authorizers=None, **data
     ):
         """Initialize a Foundry client
         Args:

--- a/tests/local_only_tests.py
+++ b/tests/local_only_tests.py
@@ -10,14 +10,26 @@ from foundry import Foundry
 from dlhub_sdk import DLHubClient
 from mdf_connect_client import MDFConnectClient
 
+services = [
+            "data_mdf",
+            "mdf_connect",
+            "search",
+            "dlhub",
+            "petrel",
+            "transfer",
+            "openid",
+            "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all",]
 
+auths = mdf_toolbox.login(services=services, make_clients=True)
+search_auth = mdf_toolbox.login(services=['search'], make_clients=False)
+auths['search_authorizer'] = search_auth['search']
 
-#updated test dataset
+# updated test dataset
 test_dataset = "_test_foundry_iris_dev_v2.1"
 expected_title = "Iris Dataset"
 
 
-#Kept the Old metadata format in case we ever want to refer back
+# Kept the Old metadata format in case we ever want to refer back
 old_test_metadata = {
     "inputs": ["sepal length (cm)", "sepal width (cm)", "petal length (cm)", "petal width (cm)"],
     "input_descriptions": ["sepal length in unit(cm)", "sepal width in unit(cm)", "petal length in unit(cm)",
@@ -30,7 +42,6 @@ old_test_metadata = {
     "short_name": "iris_example",
     "package_type": "tabular"
 }
-
 
 test_metadata = {
     "keys":[
@@ -89,11 +100,12 @@ test_metadata = {
     'domain': ['materials science', 'chemistry'],
     'n_items': 1000
 }
+
 # Globus endpoint for '_iris_dev'
 test_data_source = "https://app.globus.org/file-manager?origin_id=e38ee745-6d04-11e5-ba46-22000b92c6ec&origin_path=%2Ffoundry-test%2Firis-dev%2F"
 
 
-#Quick function to delete any downloaded test data
+# Quick function to delete any downloaded test data
 def _delete_test_data(foundry_obj):
     path = os.path.join(foundry_obj.config.local_cache_dir, test_dataset)
     if os.path.isdir(path):
@@ -102,17 +114,17 @@ def _delete_test_data(foundry_obj):
 
 @pytest.mark.xfail(reason="Tests will fail in cloud")
 def test_foundry_init_cloud():
-    f = Foundry()
+    f = Foundry(authorizers=auths)
     assert isinstance(f.dlhub_client, DLHubClient)
     assert isinstance(f.forge_client, Forge)
     assert isinstance(f.connect_client, MDFConnectClient)
 
-    f2 = Foundry(no_browser=False, no_local_server=True)
+    f2 = Foundry(authorizers=auths, no_browser=False, no_local_server=True)
     assert isinstance(f2.dlhub_client, DLHubClient)
     assert isinstance(f2.forge_client, Forge)
     assert isinstance(f2.connect_client, MDFConnectClient)
 
-    f3 = Foundry(no_browser=True, no_local_server=False)
+    f3 = Foundry(authorizers=auths, no_browser=True, no_local_server=False)
     assert isinstance(f3.dlhub_client, DLHubClient)
     assert isinstance(f3.forge_client, Forge)
     assert isinstance(f3.connect_client, MDFConnectClient)
@@ -120,9 +132,7 @@ def test_foundry_init_cloud():
 
 @pytest.mark.xfail(reason="Test should have a local endpoint, will fail cloud CI")
 def test_download_globus():
-
-
-    f = Foundry(no_browser=True, no_local_server=True)
+    f = Foundry(authorizers=auths, no_browser=True, no_local_server=True)
 
     _delete_test_data(f)
 
@@ -133,8 +143,7 @@ def test_download_globus():
 
 
 def test_globus_dataframe_load():
-
-    f = Foundry(no_browser=True, no_local_server=True)
+    f = Foundry(authorizers=auths, no_browser=True, no_local_server=True)
 
     _delete_test_data(f)
 
@@ -154,7 +163,7 @@ def test_globus_dataframe_load():
 def test_publish():
     # TODO: automate dealing with curation and cleaning after tests
 
-    f = Foundry(no_browser=True, no_local_server=True)
+    f = Foundry(authorizers=auths, index="test", no_browser=True, no_local_server=True)
 
     timestamp = datetime.now().timestamp()
     title = "scourtas_example_iris_test_publish_{:.0f}".format(timestamp)

--- a/tests/local_only_tests.py
+++ b/tests/local_only_tests.py
@@ -112,8 +112,7 @@ def _delete_test_data(foundry_obj):
         shutil.rmtree(path)
 
 
-@pytest.mark.xfail(reason="Tests will fail in cloud")
-def test_foundry_init_cloud():
+def test_foundry_init():
     f = Foundry(authorizers=auths)
     assert isinstance(f.dlhub_client, DLHubClient)
     assert isinstance(f.forge_client, Forge)
@@ -130,7 +129,6 @@ def test_foundry_init_cloud():
     assert isinstance(f3.connect_client, MDFConnectClient)
 
 
-@pytest.mark.xfail(reason="Test should have a local endpoint, will fail cloud CI")
 def test_download_globus():
     f = Foundry(authorizers=auths, no_browser=True, no_local_server=True)
 

--- a/tests/local_only_tests.py
+++ b/tests/local_only_tests.py
@@ -24,9 +24,13 @@ auths = mdf_toolbox.login(services=services, make_clients=True)
 search_auth = mdf_toolbox.login(services=['search'], make_clients=False)
 auths['search_authorizer'] = search_auth['search']
 
-# updated test dataset
-test_dataset = "_test_foundry_iris_dev_v2.1"
-expected_title = "Iris Dataset"
+# updated test dataset for publication
+pub_test_dataset = "_test_foundry_iris_dev_v2.1"
+pub_expected_title = "Iris Dataset"
+
+# test dataset for all other tests
+test_dataset = "foundry_experimental_band_gaps_v1.1"
+expected_title = "Graph Network Based Deep Learning of Band Gaps - Experimental Band Gaps"
 
 
 # Kept the Old metadata format in case we ever want to refer back
@@ -43,7 +47,7 @@ old_test_metadata = {
     "package_type": "tabular"
 }
 
-test_metadata = {
+pub_test_metadata = {
     "keys":[
         {
             "key": ["sepal length (cm)"],
@@ -101,8 +105,8 @@ test_metadata = {
     'n_items': 1000
 }
 
-# Globus endpoint for '_iris_dev'
-test_data_source = "https://app.globus.org/file-manager?origin_id=e38ee745-6d04-11e5-ba46-22000b92c6ec&origin_path=%2Ffoundry-test%2Firis-dev%2F"
+# Globus endpoint for '_iris_dev' for test publication
+pub_test_data_source = "https://app.globus.org/file-manager?origin_id=e38ee745-6d04-11e5-ba46-22000b92c6ec&origin_path=%2Ffoundry-test%2Firis-dev%2F"
 
 
 # Quick function to delete any downloaded test data
@@ -157,18 +161,17 @@ def test_globus_dataframe_load():
     _delete_test_data(f)
 
 
-
 def test_publish():
     # TODO: automate dealing with curation and cleaning after tests
 
-    f = Foundry(authorizers=auths, index="test", no_browser=True, no_local_server=True)
+    f = Foundry(authorizers=auths, index="mdf-test", no_browser=True, no_local_server=True)
 
     timestamp = datetime.now().timestamp()
     title = "scourtas_example_iris_test_publish_{:.0f}".format(timestamp)
     short_name = "example_AS_iris_test_{:.0f}".format(timestamp)
     authors = ["A Scourtas"]
 
-    res = f.publish(test_metadata, test_data_source, title, authors, short_name=short_name)
+    res = f.publish(pub_test_metadata, pub_test_data_source, title, authors, short_name=short_name)
 
     # publish with short name
     assert res['success']
@@ -176,21 +179,21 @@ def test_publish():
 
     # TODO: publish with long title -- for some reason even when I change the title, it still says it's already pub'd
     # title += "long"
-    # res = f.publish(test_metadata, test_data_source, title, authors)
+    # res = f.publish(pub_test_metadata, pub_test_data_source, title, authors)
     # assert res['success']
     # assert res['source_id'] == "_test_scourtas_example_iris_publish_{:.0f}_v1.1".format(timestamp)
 
     # check that pushing same dataset without update flag fails
-    res = f.publish(test_metadata, test_data_source, title, authors, short_name=short_name)
+    res = f.publish(pub_test_metadata, pub_test_data_source, title, authors, short_name=short_name)
     assert not res['success']
 
     # check that using update flag allows us to update dataset
-    res = f.publish(test_metadata, test_data_source, title, authors, short_name=short_name, update=True)
+    res = f.publish(pub_test_metadata, pub_test_data_source, title, authors, short_name=short_name, update=True)
     assert res['success']
 
     # check that using update flag for new dataset fails
     new_short_name = short_name + "_update"
-    res = f.publish(test_metadata, test_data_source, title, authors, short_name=new_short_name, update=True)
+    res = f.publish(pub_test_metadata, pub_test_data_source, title, authors, short_name=new_short_name, update=True)
     assert not res['success']
 
 

--- a/tests/test_foundry_gha.py
+++ b/tests/test_foundry_gha.py
@@ -15,7 +15,7 @@ from mdf_connect_client import MDFConnectClient
 client_id = os.getenv('CLIENT_ID')
 client_secret = os.getenv('CLIENT_SECRET')
 
-services= [
+services = [
             "data_mdf",
             "mdf_connect",
             "search",
@@ -36,11 +36,11 @@ search_auth = mdf_toolbox.confidential_login(client_id=client_id,
 
 auths['search_authorizer'] = search_auth['search']
 
-#updated test dataset
-test_dataset = "_test_foundry_iris_dev_v2.1"
-expected_title = "Iris Dataset"
+# updated test dataset
+test_dataset = "foundry_experimental_band_gaps_v1.1"
+expected_title = "Graph Network Based Deep Learning of Band Gaps - Experimental Band Gaps"
 
-#Kept the Old metadata format in case we ever want to refer back
+# Kept the Old metadata format in case we ever want to refer back
 old_test_metadata = {
     "inputs": ["sepal length (cm)", "sepal width (cm)", "petal length (cm)", "petal width (cm)"],
     "input_descriptions": ["sepal length in unit(cm)", "sepal width in unit(cm)", "petal length in unit(cm)",


### PR DESCRIPTION
- fix auth in `__init__()` for `Foundry` class such that the user can instantiate the class without providing `authorizers`
- fix the tests in `local_only_tests.py` to use the correct authorizers that work with Globus Search
- change the default index to `"mdf"`, i.e. the production index
- remove two decorators on local tests so that they run locally, as intended