### PR TITLE
Add search

### DIFF
--- a/foundry/foundry.py
+++ b/foundry/foundry.py
@@ -197,18 +197,23 @@ class Foundry(FoundryMetadata):
 
         return self
 
-    def list(self):
-        """List available Foundry data packages
+    def search(self, q=None, limit=None):
+        """Search available Foundry data packages
+        q (str): query string to match
+        limit (int): maximum number of results to return
 
         Returns
         -------
             (pandas.DataFrame): DataFrame with summary list of Foundry data packages including name, title, publication year, and DOI
         """
+        if not q: 
+            q = None
+        
         res = (
             self.forge_client.match_field(
                 "mdf.organizations", self.config.organization)
             .match_resource_types("dataset")
-            .search()
+            .search(q, limit=limit)
         )
 
         return pd.DataFrame(
@@ -217,11 +222,20 @@ class Foundry(FoundryMetadata):
                     "source_id": r["mdf"]["source_id"],
                     "name": r["dc"]["titles"][0]["title"],
                     "year": r["dc"].get("publicationYear", None),
-                    "DOI": r["dc"]["identifier"]["identifier"],
+                    "DOI": r["dc"].get("identifier",{}).get("identifier",None),
                 }
                 for r in res
             ]
         )
+        
+    def list(self):
+        """List available Foundry data packages
+
+        Returns
+        -------
+            (pandas.DataFrame): DataFrame with summary list of Foundry data packages including name, title, publication year, and DOI
+        """
+        return self.search()
 
     def get_packages(self, paths=False):
         """Get available local data packages

--- a/foundry/foundry.py
+++ b/foundry/foundry.py
@@ -208,9 +208,8 @@ class Foundry(FoundryMetadata):
         -------
             (pandas.DataFrame): DataFrame with summary list of Foundry data packages including name, title, publication year, and DOI
         """
-        if not q: 
+        if not q:
             q = None
-        
         res = (
             self.forge_client.match_field(
                 "mdf.organizations", self.config.organization)
@@ -224,12 +223,12 @@ class Foundry(FoundryMetadata):
                     "source_id": r["mdf"]["source_id"],
                     "name": r["dc"]["titles"][0]["title"],
                     "year": r["dc"].get("publicationYear", None),
-                    "DOI": r["dc"].get("identifier",{}).get("identifier",None),
+                    "DOI": r["dc"].get("identifier", {}).get("identifier", None),
                 }
                 for r in res
             ]
         )
-        
+
     def list(self):
         """List available Foundry data packages
 

--- a/foundry/foundry.py
+++ b/foundry/foundry.py
@@ -200,7 +200,7 @@ class Foundry(FoundryMetadata):
         return self
 
     def search(self, q=None, limit=None):
-        """Search available Foundry data packages
+        """Search available Foundry datasets
         q (str): query string to match
         limit (int): maximum number of results to return
 
@@ -230,16 +230,16 @@ class Foundry(FoundryMetadata):
         )
 
     def list(self):
-        """List available Foundry data packages
+        """List available Foundry datasets
 
         Returns
         -------
-            (pandas.DataFrame): DataFrame with summary list of Foundry data packages including name, title, publication year, and DOI
+            (pandas.DataFrame): DataFrame with summary list of Foundry datasets including name, title, publication year, and DOI
         """
         return self.search()
 
     def get_packages(self, paths=False):
-        """Get available local data packages
+        """Get available local datasets
 
         Args:
            paths (bool): If True return paths in addition to package, if False return package name only


### PR DESCRIPTION
Adding new Foundry `search()` function. Search allows users to supply a query, and specify a max number of results to find closer matching datasets than `list()` which returns every Foundry dataset.