### PR TITLE
Set Header Images to an absolute URL via raw.githubusercontent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <picture>
-  <source srcset="https://raw.githubusercontent.com/cyschneck/foundry/main/assets/foundry-light.png" height=175" media="(prefers-color-scheme: dark)">
-  <img src="https://raw.githubusercontent.com/cyschneck/foundry/main/assets/foundry-dark.png" height="175">
+  <source srcset="https://raw.githubusercontent.com/MLMI2-CSSI/foundry/main/assets/foundry-light.png" height=175" media="(prefers-color-scheme: dark)">
+  <img src="https://raw.githubusercontent.com/MLMI2-CSSI/foundry/main/assets/foundry-dark.png" height="175">
 </picture>
 
 [![PyPI](https://img.shields.io/pypi/v/foundry_ml.svg)](https://pypi.python.org/pypi/foundry_ml)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <picture>
-  <source srcset="./assets/foundry-light.png" height=175" media="(prefers-color-scheme: dark)">
-  <img src="./assets/foundry-dark.png" height="175">
+  <source srcset="https://raw.githubusercontent.com/cyschneck/foundry/main/assets/foundry-light.png" height=175" media="(prefers-color-scheme: dark)">
+  <img src="https://raw.githubusercontent.com/cyschneck/foundry/main/assets/foundry-dark.png" height="175">
 </picture>
 
 [![PyPI](https://img.shields.io/pypi/v/foundry_ml.svg)](https://pypi.python.org/pypi/foundry_ml)


### PR DESCRIPTION
The README uses relative URL links, so the header image is not visible outside of the github repo (like on pypi)

![image](https://user-images.githubusercontent.com/22159116/202331371-2e098fee-3545-497e-84be-0ccd94bcbf2a.png)
