### PR TITLE
Add website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Foundry-ML simplifies the discovery and usage of ML-ready datasets in materials 
 * Publish your own datasets with Foundry to promote community usage
 * (in progress) Run published ML models without hassle
 
+Learn more and see our available datasets on [Foundry-ML.org](https://foundry-ml.org/)
+
 
 
 # Documentation


### PR DESCRIPTION
It took me longer than it should have to find https://foundry-ml.org/

This at least adds the link to the main page from our GitHub, and we should add it to the documentation on GitBook as well (but I don't know how)