### PR TITLE
automating api documentation using github action

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,0 +1,42 @@
+name: build api documentation
+
+on:
+  pull_request:
+    types:
+      - closed
+  push:
+    branches:
+      - "*"
+
+jobs:
+  build_documentation:
+    if: github.event.pull_request.merged == true
+    name: generate api markdown docs
+    runs-on: ubuntu-latest
+    env:
+      CLIENT_ID: ${{ secrets.CLIENT_ID }}
+      CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+    steps:
+      - name: Check out repo's default branch
+        uses: actions/checkout@v3
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install lazydocs
+      - name: Build docs from docstrings
+        continue-on-error: true
+        run: |
+          lazydocs --output-path="docs" --overview-file="README.md" --src-base-url="https://github.com/MLMI2-CSSI/foundry/tree/main" .        
+      - name: Commit files
+        run: |
+          echo ${{ github.ref }}
+          git add .
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "CI: Automated documentation build" -a | exit 0
+          git push origin ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
This PR addresses #189 by creating a github action that automatically builds API documentation from docstrings. The action is set up to be triggered by a successful PR merge, and then generates the .md files into the `docs/` folder of the PR base branch. The action employs the [lazydocs](https://github.com/ml-tooling/lazydocs) package as after extensive exploration, it was the simplest and cleanest solution that I found to generate vanilla .md files. Note that there was no clear way to generate API documentation from the docstrings that integrated with gitbook - as such, the .md files created are not currently integrated into the gitbook. This documentation would also benefit from additional development to refine the docstrings.