### PR TITLE
Update requirements.txt to latest DLHub SDK

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 globus-sdk>=3,<4
-dlhub_sdk>=1.0.0
+dlhub_sdk>=2.0.3
 requests>=2.18.4
 tqdm>=4.19.4
 six>=1.11.0


### PR DESCRIPTION
This is needed to require upgrade of DLHub SDK for Foundry users when they upgrade Foundry.