### PR TITLE
Split specification

### DIFF
--- a/foundry/foundry.py
+++ b/foundry/foundry.py
@@ -266,7 +266,7 @@ class Foundry(FoundryMetadata):
             self.dlhub_client.fx_endpoint = funcx_endpoint
         return self.dlhub_client.run(name, inputs=inputs, **kwargs)
 
-    def load_data(self, source_id=None, globus=True, as_hdf5=False, splits_to_load=[]):
+    def load_data(self, source_id=None, globus=True, as_hdf5=False, splits=[]):
         """Load in the data associated with the prescribed dataset
 
         Tabular Data Type: Data are arranged in a standard data frame
@@ -292,23 +292,23 @@ class Foundry(FoundryMetadata):
         # Handle splits if they exist. Return as a labeled dictionary of tuples
         try:
             if self.dataset.splits:
-                if not splits_to_load:
+                if not splits:
                     for split in self.dataset.splits:
                         data[split.label] = self._load_data(file=split.path, source_id=source_id, globus=globus,
                                                             as_hdf5=as_hdf5)
                 else:
                     for split in self.dataset.splits:
-                        if split.label in splits_to_load:
-                            splits_to_load.remove(split.label)
+                        if split.label in splits:
+                            splits.remove(split.label)
                             data[split.label] = self._load_data(file=split.path, source_id=source_id, globus=globus,
                                                                 as_hdf5=as_hdf5)
-                    if len(splits_to_load) > 0:
-                        raise ValueError(f'The split(s) {splits_to_load} were not found in the dataset!')
+                    if len(splits) > 0:
+                        raise ValueError(f'The split(s) {splits} were not found in the dataset!')
                 return data
             else:
                 # raise an error if splits are specified but not present in the dataset
-                if len(splits_to_load) > 0:
-                    raise ValueError(f"Splits to load were specified as {splits_to_load}, but no splits are present in dataset")
+                if len(splits) > 0:
+                    raise ValueError(f"Splits to load were specified as {splits}, but no splits are present in dataset")
                 return {"data": self._load_data(source_id=source_id, globus=globus, as_hdf5=as_hdf5)}
         except Exception as e:
             raise Exception(

--- a/foundry/foundry.py
+++ b/foundry/foundry.py
@@ -259,15 +259,14 @@ class Foundry(FoundryMetadata):
            inputs: Data to send to DLHub as inputs (should be JSON serializable)
            funcx_endpoint (optional): UUID for the funcx endpoint to run the model on, if not the default (eg River)
 
-        Returns
-        -------
+        Returns:
              Returns results after invocation via the DLHub service
         """
         if funcx_endpoint is not None:
             self.dlhub_client.fx_endpoint = funcx_endpoint
         return self.dlhub_client.run(name, inputs=inputs, **kwargs)
 
-    def load_data(self, source_id=None, globus=True, as_hdf5=False):
+    def load_data(self, source_id=None, globus=True, as_hdf5=False, splits_to_load=[]):
         """Load in the data associated with the prescribed dataset
 
         Tabular Data Type: Data are arranged in a standard data frame
@@ -283,21 +282,33 @@ class Foundry(FoundryMetadata):
            targets (list): List of strings for output columns
            source_id (string): Relative path to the source file
            as_hdf5 (bool): If True and dataset is in hdf5 format, keep data in hdf5 format
+           splits (list): Labels of splits to be loaded
 
-        Returns
-        -------
-             (tuple): Tuple of X, y values
+        Returns:
+             (dict): a labeled dictionary of tuples
         """
         data = {}
 
         # Handle splits if they exist. Return as a labeled dictionary of tuples
         try:
             if self.dataset.splits:
-                for split in self.dataset.splits:
-                    data[split.label] = self._load_data(file=split.path, source_id=source_id, globus=globus,
-                                                        as_hdf5=as_hdf5)
+                if not splits_to_load:
+                    for split in self.dataset.splits:
+                        data[split.label] = self._load_data(file=split.path, source_id=source_id, globus=globus,
+                                                            as_hdf5=as_hdf5)
+                else:
+                    for split in self.dataset.splits:
+                        if split.label in splits_to_load:
+                            splits_to_load.remove(split.label)
+                            data[split.label] = self._load_data(file=split.path, source_id=source_id, globus=globus,
+                                                                as_hdf5=as_hdf5)
+                    if len(splits_to_load) > 0:
+                        raise ValueError(f'The split(s) {splits_to_load} were not found in the dataset!')
                 return data
             else:
+                # raise an error if splits are specified but not present in the dataset
+                if len(splits_to_load) > 0:
+                    raise ValueError(f"Splits to load were specified as {splits_to_load}, but no splits are present in dataset")
                 return {"data": self._load_data(source_id=source_id, globus=globus, as_hdf5=as_hdf5)}
         except Exception as e:
             raise Exception(

--- a/tests/test_foundry.py
+++ b/tests/test_foundry.py
@@ -214,6 +214,40 @@ def test_dataframe_load():
     _delete_test_data(f)
 
 
+def test_dataframe_load_split():
+    f = Foundry(authorizers=auths)
+    _delete_test_data(f)
+
+    f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
+    res = f.load_data(splits_to_load=['train'])
+    X, y = res['train']
+
+    assert len(X) > 1
+    assert isinstance(X, pd.DataFrame)
+    assert len(y) > 1
+    assert isinstance(y, pd.DataFrame)
+    _delete_test_data(f)
+
+
+def test_dataframe_load_split_wrong_split_name():
+    f = Foundry(authorizers=auths)
+    _delete_test_data(f)
+
+    f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
+    with pytest.raises(Exception):
+        f.load_data(splits_to_load=['chewbacca'])
+
+
+@pytest.mark.skip(reason='No clear examples of datasets without splits - likely to be protected against soon.')
+def test_dataframe_load_split_but_no_splits():
+    f = Foundry(authorizers=auths)
+    _delete_test_data(f)
+
+    f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
+    with pytest.raises(ValueError):
+        f.load_data(splits_to_load=['train'])
+
+
 def test_dataframe_load_doi():
     f = Foundry(authorizers=auths)
     _delete_test_data(f)

--- a/tests/test_foundry.py
+++ b/tests/test_foundry.py
@@ -234,8 +234,12 @@ def test_dataframe_load_split_wrong_split_name():
     _delete_test_data(f)
 
     f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as exc_info:
         f.load_data(splits_to_load=['chewbacca'])
+
+    err = exc_info.value
+    assert hasattr(err, '__cause__')
+    assert isinstance(err.__cause__, ValueError)
 
 
 @pytest.mark.skip(reason='No clear examples of datasets without splits - likely to be protected against soon.')

--- a/tests/test_foundry.py
+++ b/tests/test_foundry.py
@@ -219,7 +219,7 @@ def test_dataframe_load_split():
     _delete_test_data(f)
 
     f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
-    res = f.load_data(splits_to_load=['train'])
+    res = f.load_data(splits=['train'])
     X, y = res['train']
 
     assert len(X) > 1
@@ -235,7 +235,7 @@ def test_dataframe_load_split_wrong_split_name():
 
     f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
     with pytest.raises(Exception) as exc_info:
-        f.load_data(splits_to_load=['chewbacca'])
+        f.load_data(splits=['chewbacca'])
 
     err = exc_info.value
     assert hasattr(err, '__cause__')
@@ -249,7 +249,7 @@ def test_dataframe_load_split_but_no_splits():
 
     f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
     with pytest.raises(ValueError):
-        f.load_data(splits_to_load=['train'])
+        f.load_data(splits=['train'])
 
 
 def test_dataframe_load_doi():


### PR DESCRIPTION
Addressing #316 - added the ability to specify a list of splits by label for loading when using the `load_data()` function. Added some ValueError exceptions if there are splits that are requested but not in the dataset, as well as if splits are requested but no splits are present.

Note that testing around the lack of splits in the dataset is currently skipped, as there aren't any obvious datasets that don't have splits that can be used for testing, and from discussions it sounds like that will be protected against in the near future.

Also updated the docstring for `load_data()` to comply with google docstring format and reflect that it returns a `dict`.