### PR TITLE
Add a Dependabot config to autoupdate GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
I noticed some deprecation warnings in CI caused by out-of-date action versions ([recent example](https://github.com/MLMI2-CSSI/foundry/actions/runs/5786400511)).

Rather than update out-of-date action versions once, this PR introduces a Dependabot config that will keep the actions up-to-date in perpetuity. If this PR merges, you can anticipate Dependabot immediately opening one or more PRs to address out-of-date action versions.

PS -- I enjoyed the talk today! Thanks for sharing!