### PR TITLE
remove breaking changes that load on init

### DIFF
--- a/tests/test_foundry.py
+++ b/tests/test_foundry.py
@@ -207,33 +207,33 @@ def _delete_test_data(foundry_obj):
 
 
 def test_foundry_init():
-    f = Foundry(test_dataset, download=False, authorizers=auths)
+    f = Foundry(authorizers=auths)
     assert isinstance(f.forge_client, Forge)
     assert isinstance(f.connect_client, MDFConnectClient)
 
     if not is_gha:
         assert isinstance(f.dlhub_client, DLHubClient)
 
-        f2 = Foundry(test_dataset, download=False, authorizers=auths, no_browser=False, no_local_server=True)
+        f2 = Foundry(authorizers=auths, no_browser=False, no_local_server=True)
         assert isinstance(f2.dlhub_client, DLHubClient)
         assert isinstance(f2.forge_client, Forge)
         assert isinstance(f2.connect_client, MDFConnectClient)
 
-        f3 = Foundry(test_dataset, download=False, authorizers=auths, no_browser=True, no_local_server=False)
+        f3 = Foundry(authorizers=auths, no_browser=True, no_local_server=False)
         assert isinstance(f3.dlhub_client, DLHubClient)
         assert isinstance(f3.forge_client, Forge)
         assert isinstance(f3.connect_client, MDFConnectClient)
 
 
 def test_list():
-    f = Foundry(test_dataset, download=False, authorizers=auths)
+    f = Foundry(authorizers=auths)
     ds = f.list()
     assert isinstance(ds, pd.DataFrame)
     assert len(ds) > 0
 
 
 def test_search():
-    f = Foundry(test_dataset, download=False, authorizers=auths)
+    f = Foundry(authorizers=auths)
     q = "Elwood"
     ds = f.search(q)
 
@@ -245,20 +245,25 @@ def test_search():
 
 
 def test_metadata_pull():
-    f = Foundry(test_dataset, download=False, authorizers=auths)
+    f = Foundry(authorizers=auths)
+    assert f.dc == {}
+    f = f.load(test_dataset, download=False, authorizers=auths)
     assert f.dc["titles"][0]["title"] == expected_title
 
 
 def test_download_https():
-    f = Foundry(test_dataset, download=True, globus=False, authorizers=auths)
+    f = Foundry(authorizers=auths)
     _delete_test_data(f)
+    f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
 
     assert f.dc["titles"][0]["title"] == expected_title
     _delete_test_data(f)
 
 
 def test_dataframe_load():
-    f = Foundry(test_dataset, download=True, globus=False, authorizers=auths)
+    f = Foundry(authorizers=auths)
+    _delete_test_data(f)
+    f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
 
     res = f.load_data()
     X, y = res['train']
@@ -271,7 +276,9 @@ def test_dataframe_load():
 
 
 def test_dataframe_load_split():
-    f = Foundry(test_dataset, download=True, globus=False, authorizers=auths)
+    f = Foundry(authorizers=auths)
+    _delete_test_data(f)
+    f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
 
     res = f.load_data(splits=['train'])
     X, y = res['train']
@@ -284,7 +291,9 @@ def test_dataframe_load_split():
 
 
 def test_dataframe_load_split_wrong_split_name():
-    f = Foundry(test_dataset, download=True, globus=False, authorizers=auths)
+    f = Foundry(authorizers=auths)
+    _delete_test_data(f)
+    f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
 
     with pytest.raises(Exception) as exc_info:
         f.load_data(splits=['chewbacca'])
@@ -297,7 +306,9 @@ def test_dataframe_load_split_wrong_split_name():
 
 @pytest.mark.skip(reason='No clear examples of datasets without splits - likely to be protected against soon.')
 def test_dataframe_load_split_but_no_splits():
-    f = Foundry(test_dataset, download=True, globus=False, authorizers=auths)
+    f = Foundry(authorizers=auths)
+    _delete_test_data(f)
+    f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
 
     with pytest.raises(ValueError):
         f.load_data(splits=['train'])
@@ -305,7 +316,9 @@ def test_dataframe_load_split_but_no_splits():
 
 
 def test_dataframe_load_doi():
-    f = Foundry(test_doi, download=True, globus=False, authorizers=auths)
+    f = Foundry(authorizers=auths)
+    _delete_test_data(f)
+    f = f.load(test_doi, download=True, globus=False, authorizers=auths)
 
     res = f.load_data()
     X, y = res['train']
@@ -319,8 +332,9 @@ def test_dataframe_load_doi():
 
 @pytest.mark.skipif(bool(is_gha), reason="Test does not succeed on GHA - no Globus endpoint")
 def test_download_globus():
-    f = Foundry(test_dataset, download=True, authorizers=auths, no_browser=True, no_local_server=True)
+    f = Foundry(authorizers=auths, no_browser=True, no_local_server=True)
     _delete_test_data(f)
+    f = f.load(test_dataset, download=True)
 
     assert f.dc["titles"][0]["title"] == expected_title
     _delete_test_data(f)
@@ -328,7 +342,11 @@ def test_download_globus():
 
 @pytest.mark.skipif(bool(is_gha), reason="Test does not succeed on GHA - no Globus endpoint")
 def test_globus_dataframe_load():
-    f = Foundry(test_dataset, download=True, authorizers=auths, no_browser=True, no_local_server=True)
+    f = Foundry(authorizers=auths, no_browser=True, no_local_server=True)
+
+    _delete_test_data(f)
+
+    f = f.load(test_dataset, download=True)
 
     res = f.load_data()
     X, y = res['train']
@@ -482,7 +500,9 @@ def test_check_status():
 
 
 def test_to_pytorch():
-    f = Foundry(test_dataset, download=True, globus=False, authorizers=auths, no_browser=True, no_local_server=True)
+    f = Foundry(authorizers=auths, no_browser=True, no_local_server=True)
+    _delete_test_data(f)
+    f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
 
     raw = f.load_data()
 
@@ -495,7 +515,9 @@ def test_to_pytorch():
 
 
 def test_to_tensorflow():
-    f = Foundry(test_dataset, download=True, globus=False, authorizers=auths, no_browser=True, no_local_server=True)
+    f = Foundry(authorizers=auths, no_browser=True, no_local_server=True)
+    _delete_test_data(f)
+    f = f.load(test_dataset, download=True, globus=False, authorizers=auths)
 
     raw = f.load_data()
 


### PR DESCRIPTION
Fix up `main` to revert load on init() changes previously merged, but keep flake8 fixes, comments, docs, metadata validation, and minor tweaks. This means we preserve previous functionality for users when loading datasets, but keep all other changes.

This should keep `main` "clean" such that we can cut a minor/patch release before the new code-breaking changes of the class refactor are merged. 