### PR TITLE
Joss https default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ from foundry import Foundry
 f = Foundry(index="mdf")
 
 
-f = f.load("10.18126/e73h-3w6n", globus=True)
+f = f.load("10.18126/e73h-3w6n", globus=False)
 ```
-*NOTE*: If you run locally and don't want to install the [Globus Connect Personal endpoint](https://www.globus.org/globus-connect-personal), just set the `globus=False`.
+*NOTE*: This will download the dataset using HTTPS; if you want to download a very large dataset, set `globus=True` and be sure to install the [Globus Connect Personal endpoint](https://www.globus.org/globus-connect-personal).
 
 If running this code in a notebook, a table of metadata for the dataset will appear:
 

--- a/foundry/foundry.py
+++ b/foundry/foundry.py
@@ -150,8 +150,8 @@ class Foundry(FoundryBase):
 
         Args:
             name (str): Name of the foundry dataset
-            download (bool): If True, download the data associated with the package (default is True)
-            globus (bool): If True, download using Globus, otherwise https
+            download (bool): If True, download the data associated with the package. Default is True.
+            globus (bool): If True, download using Globus, otherwise HTTPS. Default is False.
             verbose (bool): If True print additional debug information
             metadata (dict): **For debug purposes.** A search result analog to prepopulate metadata.
         Keyword Args: (TODO: make this a regular arg instead?)
@@ -536,12 +536,12 @@ class Foundry(FoundryBase):
         self.config = FoundryConfig(**kwargs)
         return self
 
-    def download(self, globus: bool = True, interval: int = 20, parallel_https: int = 4, verbose: bool = False) -> \
+    def download(self, globus: bool = False, interval: int = 20, parallel_https: int = 4, verbose: bool = False) -> \
             'Foundry':
         """Download a Foundry dataset
 
         Args:
-            globus (bool): if True, use Globus to download the data else try HTTPS
+            globus (bool): if True, use Globus to download the data else try HTTPS. Default is False
             interval (int): How often to wait before checking Globus transfer status
             parallel_https (int): Number of files to download in parallel if using HTTPS
             verbose (bool): Produce more debug messages to screen


### PR DESCRIPTION
Set download default to HTTPS instead of Globus, and update the Quick Start documentation in the README accordingly. 

Note: the code previously included HTTPS as the default for `load()`, but not for `download()`, and it was not reflected in the docstrings nor the README documentation -- this PR rectifies that. 

Fixes #372 