### PR TITLE
Create data_publish issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/data_publish
+++ b/.github/ISSUE_TEMPLATE/data_publish
@@ -1,0 +1,26 @@
+---
+name: Dataset Publishing Request
+about: Submit a request for a dataset you want published to Foundry
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the dataset**
+A clear and concise description of the dataset.
+
+**Where is the dataset?**
+Post a link to where we can find the data here
+  
+**Where can we find the metadata?**
+Either put the metadata here or link to a page that has the information we need. Our metadata requirements are in our [documentation](https://ai-materials-and-chemistry.gitbook.io/foundry/publishing/describing-datasets).
+
+**Resources for publishing**
+Leave this section in your issue for people who may pick it up.
+1. Documentation for shaping the data: https://ai-materials-and-chemistry.gitbook.io/foundry/publishing/publishing-datasets
+2. Documentation for metadata: https://ai-materials-and-chemistry.gitbook.io/foundry/publishing/describing-datasets
+3. Publishing notebook - swap in this dataset's information and publish within the notebook: https://github.com/MLMI2-CSSI/foundry/blob/main/examples/publishing-guides/dataset_publishing.ipynb
+
+**Additional context**
+Add any other context about the dataset here.


### PR DESCRIPTION
Created an issue template for people to request datasets they want on foundry. I included links to the documentation so whoever picks up the issue will have resources for shaping data, creating metadata, and publishing.